### PR TITLE
Add support for Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,18 @@
+FROM python:3.5
+
+MAINTAINER Rémy Greinhofer <remy.greinhofer@gmail.com>
+
+# Create the directory containing the code.
+RUN mkdir /code
+WORKDIR /code
+
+# Define environment variables.
+ENV PYTHONUNBUFFERED 1
+ENV DATABASE_URL postgres://postgres:postgres@db:5432/postgres
+ENV REDIS_URL redis://redis:6379
+
+# Copy the requirements files.
+COPY requirements/* /code/
+
+# Install the pip packages.
+RUN pip install -q -r local.txt

--- a/craigomatic/settings/base.py
+++ b/craigomatic/settings/base.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import dj_database_url
+
 # PATH vars
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -16,12 +18,12 @@ SECRET_KEY = 'CHANGE THIS!!!'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-IN_TESTING = sys.argv[1:2] == ['test']
 
-ALLOWED_HOSTS = []
+# Allow all host headers
+# SECURITY WARNING: don't run with this setting in production!
+ALLOWED_HOSTS = ['*']
 
 # Application definition
-
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -61,15 +63,10 @@ MANAGERS = ADMINS
 WSGI_APPLICATION = 'craigomatic.wsgi.application'
 
 # Internationalization
-
 LANGUAGE_CODE = 'en-us'
-
 TIME_ZONE = 'America/Chicago'
-
 USE_I18N = True
-
 USE_L10N = True
-
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
@@ -85,6 +82,7 @@ STATICFILES_DIRS = (
 # https://warehouse.python.org/project/whitenoise/
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
+# Templates
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -108,7 +106,6 @@ TEMPLATES = [
 ]  # yapf: disable
 
 # Password validation
-
 AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
@@ -124,18 +121,21 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Database
+# https://docs.djangoproject.com/en/1.9/ref/settings/#databases
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}  # yapf: disable
+
+# Update database configuration with ${DATABASE_URL}.
+db_from_env = dj_database_url.config(conn_max_age=500)
+DATABASES['default'].update(db_from_env)
+
 # Django-crontab
 CRONJOBS = [
-    ('* 4,10,16,22 * * *', 'craigmine.management.commands.index,index_content'),
+    ('* 4,10,16,22 * * *', 'craigmine.management.commands.index.index_content'),
     ('* 2 * * *', 'craigmine.management.commands.purge.delete_items', ['7']),
 ]
-
-# .local.py overrides all the common settings.
-try:
-    from .local import *  # noqa
-except ImportError:
-    pass
-
-# importing test settings file if necessary
-if IN_TESTING:
-    from .testing import *  # noqa

--- a/craigomatic/settings/base.py
+++ b/craigomatic/settings/base.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import urlparse
 import sys
 
 import dj_database_url
@@ -133,6 +134,19 @@ DATABASES = {
 # Update database configuration with ${DATABASE_URL}.
 db_from_env = dj_database_url.config(conn_max_age=500)
 DATABASES['default'].update(db_from_env)
+
+# Cache
+redis_url = urlparse(os.environ.get('REDIS_URL'))
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "{0}:{1}".format(redis_url.hostname, redis_url.port),
+        "OPTIONS": {
+            "PASSWORD": redis_url.password,
+            "DB": 0,
+        }
+    }
+}
 
 # Django-crontab
 CRONJOBS = [

--- a/craigomatic/settings/local.py
+++ b/craigomatic/settings/local.py
@@ -1,16 +1,1 @@
 from .base import *  # noqa
-
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-#         'NAME': 'craigomatic',
-#         'USER': 'postgres',
-#         'PASSWORD': '',
-#         'HOST': 'localhost',
-#         'PORT': '',
-#     }
-# }
-
-# You might want to use sqlite3 for testing in local as it's much faster.
-# if IN_TESTING:
-DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': '/tmp/craigomatic_test.db', }}

--- a/craigomatic/settings/production.py
+++ b/craigomatic/settings/production.py
@@ -3,11 +3,14 @@ import os
 
 import dj_database_url
 
+# Disable debug modes.
 DEBUG = False
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 
+# Get tbe production secret from the environment variables.
 SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 
+# Get tbe production allowed hosts from the environment variables, or limit it to localhost only.
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', 'localhost').split(',')
 
 # Update database configuration with ${DATABASE_URL}.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  db:
+    image: postgres
+  nginx:
+    build: ./docker/nginx
+    depends_on:
+      - django
+    ports:
+      - "80:80"
+  redis:
+    image: redis:3.0
+  django:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: gunicorn -b 0.0.0.0:8000 craigomatic.wsgi 
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+      - redis

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:latest
+MAINTAINER Rémy Greinhofer <remy.greinhofer@gmail.com
+
+# Copy custom configuration file.
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,46 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    upstream app {
+        server django:8000;
+    }
+
+    server {
+        listen 80;
+        charset     utf-8;
+
+        location / {
+            # checks for static file, if not found proxy to app
+            try_files $uri @proxy_to_app;
+        }
+
+        location @proxy_to_app {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+
+            proxy_pass   http://app;
+        }
+    }
+}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,10 @@
 Django==1.9.4
+dj-database-url==0.4.0
 django-crontab==0.7.1
 django-model-utils==2.4
+gunicorn==19.4.5
 lxml==3.6.0
 pbr==1.8.1
 psycopg2==2.6.1
 requests==2.9.1
+whitenoise==3.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,5 +1,1 @@
 -r base.txt
-
-dj-database-url==0.4.0
-gunicorn==19.4.5
-whitenoise==3.0


### PR DESCRIPTION
Adds the support for a Docker based developer environment. It uses Gunicorn
to serve the Django content, behind an Nginx server, Postgresql as the
database of choice, and Redis as a cache server.
- Create Docker files for the custom images
- Create a Docker compose file
- Update requirements
